### PR TITLE
Fix behaviour for Parser.handle/2

### DIFF
--- a/lib/slax/parser.ex
+++ b/lib/slax/parser.ex
@@ -1,7 +1,9 @@
 defmodule Slax.Parser do
+  alias Slax.Event.{Characters, EndDocument, EndElement, EndPrefixMapping, Error, IgnorableWhitespace, InternalError, ProcessingInstruction, StartDocument, StartElement, StartPrefixMapping}
+
   @callback init(arg :: any) :: any
   @callback finalize(arg :: any) :: any
-  @callback handle(tuple(), arg :: any) :: any
+  @callback handle(arg :: (Characters.t | EndDocument.t | EndElement.t | EndPrefixMapping.t | Error.t | IgnorableWhitespace.t | InternalError.t | ProcessingInstruction.t | StartDocument.t | StartElement.t | StartPrefixMapping.t), arg :: any) :: any
   @optional_callbacks init: 1
 
   defmacro __using__(opts \\ []) do


### PR DESCRIPTION
Running dialyzer results in

```callback_arg_type_mismatch
The inferred type for the 1st argument is not a
supertype of the expected type for the handle/2 callback
in the Slax.Parser behaviour.

Success type:
%Slax.Event.Characters{_ => _}

Behaviour callback type:
tuple()
```

This fixes this, by changing the behaviour to the appropriate types.